### PR TITLE
feat: adds s3 workflow

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,0 +1,29 @@
+name: Upload data
+on:
+  push:
+    branches:
+      - main
+jobs:
+  upload-folder:
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
+      AWS_BUCKET: 'aind-ephys-data'
+      AWS_SECRETS_NAME: '/aind/data/transfer/secrets'
+      AWS_PARAM_STORE: '/aind/data/transfer/endpoints'
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 2
+      - name: Pull latest changes
+        run: git pull origin main
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.8
+      - name: create and upload folders
+        run: |
+          python -m pip install --no-cache-dir -r upload_scripts/requirements.txt
+          echo "Running upload data script"
+          python upload_scripts/upload_data.py -b ${AWS_BUCKET} -p ${AWS_PARAM_STORE} -s ${AWS_SECRETS_NAME}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,142 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# MacOs
+**/.DS_Store
+
+.vscode
+

--- a/upload_scripts/requirements.txt
+++ b/upload_scripts/requirements.txt
@@ -1,0 +1,4 @@
+aind-data-schema==0.12.20
+aind-codeocean-api==0.2.1
+boto3==1.26.99
+awscli==1.27.100

--- a/upload_scripts/upload_data.py
+++ b/upload_scripts/upload_data.py
@@ -1,0 +1,207 @@
+import argparse
+import json
+import os.path
+import platform
+import re
+import shutil
+import subprocess
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import boto3
+from aind_codeocean_api.codeocean import CodeOceanClient
+from aind_data_schema.data_description import (
+    DataRegex,
+    DerivedDataDescription,
+    Funding,
+    Institution,
+    Modality,
+    build_data_name,
+)
+from botocore.exceptions import ClientError
+
+
+def _get_list_of_folders_to_upload():
+    if platform.system() == "Windows":
+        shell = True
+    else:
+        shell = False
+    latest_commit_id = str(
+        subprocess.run(
+            ["git", "log", "-1", "--pretty=format:%h"],
+            stdout=subprocess.PIPE,
+            shell=shell,
+        ).stdout.decode("utf-8")
+    )
+    latest_commit_timestamp = int(
+        subprocess.run(
+            ["git", "show", "-s", "--format=%ct", latest_commit_id],
+            stdout=subprocess.PIPE,
+            shell=shell,
+        ).stdout.decode("utf-8")
+    )
+    datetime_from_commit = datetime.utcfromtimestamp(latest_commit_timestamp)
+    files_in_last_commit = str(
+        subprocess.run(
+            ["git", "log", "-1", "--pretty=oneline", "--name-status"],
+            stdout=subprocess.PIPE,
+            shell=shell,
+        ).stdout.decode("utf-8")
+    )
+    root_folders_added = set(
+        [
+            f.split("\t")[-1].split("/")[0]
+            for f in files_in_last_commit.split("\n")
+            if f.startswith("A\tecephys")
+        ]
+    )
+
+    return datetime_from_commit, root_folders_added
+
+
+def _download_params_from_aws(store_name):
+    """Attempt to download the endpoints from an aws parameter store"""
+    ssm_client = boto3.client("ssm")
+    try:
+        param_from_store = ssm_client.get_parameter(Name=store_name)
+        param_string = param_from_store["Parameter"]["Value"]
+        params = json.loads(param_string)
+    except ClientError as e:
+        print(f"WARNING: Unable to retrieve parameters from aws: {e.response}")
+        params = None
+    finally:
+        ssm_client.close()
+    return params
+
+
+def _download_secrets_from_aws(secrets_name):
+    """Attempt to download the endpoints from an aws secrets manager"""
+    sm_client = boto3.client("secretsmanager")
+    try:
+        secret_from_aws = sm_client.get_secret_value(SecretId=secrets_name)
+        secret_as_string = secret_from_aws["SecretString"]
+        secrets = json.loads(secret_as_string)
+    except ClientError as e:
+        print(f"WARNING: Unable to retrieve parameters from aws: {e.response}")
+        secrets = None
+    finally:
+        sm_client.close()
+    return secrets
+
+
+def upload_derived_data_contents_to_s3(
+    path_to_curated_dir: Path,
+    s3_bucket: str,
+    datetime_from_commit: Optional[datetime] = None,
+    dryrun=None,
+):
+    process_name = "curated"
+    creation_datetime = (
+        datetime.utcnow() if datetime_from_commit is None else datetime_from_commit
+    )
+    modality = Modality.ECEPHYS.value
+    institution = Institution.AIND.value
+    m = re.match(f"{DataRegex.RAW_DATA.value}", path_to_curated_dir.name)
+    subject_id = m.group(2)
+    funding_source = [Funding(funder=institution)]
+
+    derived_data = DerivedDataDescription(
+        creation_date=creation_datetime.date(),
+        creation_time=creation_datetime.time(),
+        process_name=process_name,
+        input_data_name=path_to_curated_dir.name,
+        modality=modality,
+        institution=institution,
+        subject_id=subject_id,
+        funding_source=funding_source,
+    )
+
+    new_path_name_suffix = build_data_name(
+        label=process_name,
+        creation_date=creation_datetime.date(),
+        creation_time=creation_datetime.time(),
+    )
+    s3_prefix = path_to_curated_dir.name + f"_{new_path_name_suffix}"
+
+    with tempfile.TemporaryDirectory() as td:
+        files_to_upload_path = os.path.join(td, "files_to_upload")
+        shutil.copytree(path_to_curated_dir, files_to_upload_path)
+        derived_data_filename = derived_data.default_filename()
+        output_file_name = os.path.join(files_to_upload_path, derived_data_filename)
+        with open(output_file_name, "w") as f:
+            f.write(derived_data.json(indent=3))
+        if platform.system() == "Windows":
+            shell = True
+        else:
+            shell = False
+        aws_dest = f"s3://{s3_bucket}/{s3_prefix}"
+        base_command = ["aws", "s3", "sync", files_to_upload_path, aws_dest]
+        if dryrun:
+            base_command.append("--dryrun")
+        subprocess.run(base_command, shell=shell)
+    return s3_prefix
+
+
+def register_to_codeocean(
+    param_store_name: str, secrets_name: str, s3_bucket: str, s3_prefix: str
+):
+    params = _download_params_from_aws(param_store_name)
+    secrets = _download_secrets_from_aws(secrets_name)
+    co_token = secrets["code_ocean_api_token"]
+    co_domain = params["codeocean_domain"]
+    capsule_id = params["codeocean_trigger_capsule_id"]
+    co_client = CodeOceanClient(domain=co_domain, token=co_token)
+
+    co_job_params = {
+        "trigger_codeocean_job": {
+            "job_type": "register_data",
+            "capsule_id": capsule_id,
+            "bucket": s3_bucket,
+            "prefix": s3_prefix,
+        }
+    }
+
+    run_response = co_client.run_capsule(
+        capsule_id=capsule_id,
+        data_assets=[],
+        parameters=[co_job_params],
+    )
+    print(run_response.json())
+
+    return None
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-b", "--s3-bucket", type=str)
+    parser.add_argument("-p", "--param-store", type=str)
+    parser.add_argument("-s", "--secrets-name", type=str)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.set_defaults(dry_run=False)
+    args = parser.parse_args()
+
+    datetime_of_commit, folders_added = _get_list_of_folders_to_upload()
+    print("Datetime of last commit: ", datetime_of_commit)
+    print("Ecephys folders added in last commit: ", folders_added)
+
+    for folder_name in folders_added:
+        s3_prefix = upload_derived_data_contents_to_s3(
+            path_to_curated_dir=Path(folder_name),
+            s3_bucket=args.s3_bucket,
+            datetime_from_commit=datetime_of_commit,
+            dryrun=args.dry_run,
+        )
+        if args.dry_run is False:
+            register_to_codeocean(
+                param_store_name=args.param_store,
+                secrets_name=args.secrets_name,
+                s3_bucket=args.s3_bucket,
+                s3_prefix=s3_prefix,
+            )
+        else:
+            print(
+                f"Dry-run set to true. Would have tried to register "
+                f"s3://{args.s3_bucket}/{s3_prefix}"
+            )


### PR DESCRIPTION
Closes #2 

- Adds script to build metadata file, rename folder, upload folder to s3, and registers the data asset to code ocean
- A bit of a hack, but should work until we can write directly to s3
- Uses git to check which files were added in the most recent commit, and then uses that information to drive the rest of the python script.
- Will need to manually do a bulk upload before the pr is merged.